### PR TITLE
Fix setting no basestack: don't send basestack

### DIFF
--- a/src/components/NewStack.js
+++ b/src/components/NewStack.js
@@ -156,7 +156,15 @@ class NewStack extends PureComponent {
       return
     }
 
-    createStack(this.state.name, this.state.operations, this.state.options)
+    let options = this.state.options
+    Object.keys(options).forEach(key => {
+      const val = options[key]
+      if (val === null || val === this.props.stackOptions[key].default) {
+        delete options[key]
+      }
+    })
+
+    createStack(this.state.name, this.state.operations, options)
       .then(({ body }) => {
         return Promise.all([body, refreshStacks()])
       })


### PR DESCRIPTION
Don't send stack option if the option is null or if it's the same
as the default from the API.