### PR TITLE
Fix options controlled<->uncontrolled comp switch

### DIFF
--- a/src/components/NewStack.js
+++ b/src/components/NewStack.js
@@ -34,6 +34,10 @@ function generateDefaultValuesStackOptions (options, stackOptions) {
   return options
 }
 
+const ajv = new Ajv({
+  allErrors: true
+})
+
 const OPTIONS = ['png.compression_level', 'jpg.quality', 'webp.quality', 'interlacing.mode', 'basestack']
 
 export class NewStack extends PureComponent {
@@ -53,7 +57,8 @@ export class NewStack extends PureComponent {
     }, {})
 
     if (props.stackOptions) {
-      options = generateDefaultValuesStackOptions(options, props.stackOptions)
+      options = generateDefaultValuesStackOptions(options, props.stackOptions.properties)
+      this.optionValidator = ajv.compile(props.stackOptions)
     }
 
     if (stackClone.operations) {
@@ -100,14 +105,10 @@ export class NewStack extends PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
-    const ajv = new Ajv({
-      allErrors: true
-    })
-
     if (nextProps.previewImage && this.props.previewImage && nextProps.previewImage.hash !== this.props.previewImage.hash) {
       this.updatePreview(nextProps.previewImage)
     }
-    if (nextProps.stackOptions !== null) {
+    if (nextProps.stackOptions !== null && !this.optionValidator) {
       const defaultOptions = generateDefaultValuesStackOptions(Object.assign({}, this.state.options), nextProps.stackOptions.properties)
       this.optionValidator = ajv.compile(nextProps.stackOptions)
 

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -13,6 +13,7 @@ class Options extends Component {
     if (!Object.keys(defaultOptions).length) {
       return null
     }
+
     return (
       <div>
         <h3 className="rka-h2 mv-md">Options</h3>

--- a/src/components/operations/Composition.js
+++ b/src/components/operations/Composition.js
@@ -101,7 +101,7 @@ Composition.propTypes = {
     height: PropTypes.string,
     anchor: PropTypes.string,
     secondary_color: PropTypes.string,
-    secondary_opacity: PropTypes.string
+    secondary_opacity: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   }),
   required: PropTypes.array.isRequired,
   errors: PropTypes.object

--- a/src/components/options/Compression.js
+++ b/src/components/options/Compression.js
@@ -5,11 +5,13 @@ import FormGroup from '../forms/FormGroup'
 
 class Compression extends Component {
   render () {
+    const { onChange, min, max, value, error } = this.props
+
     return (
-      <FormGroup label="PNG Image compression" error={this.props.error}>
-        <InputRange onChange={this.props.onChange}
-          min={this.props.min} max={this.props.max}
-          name="png.compression_level" value={this.props.value}
+      <FormGroup label="PNG Image compression" error={error}>
+        <InputRange onChange={onChange}
+          min={min} max={max}
+          name="png.compression_level" value={value}
         />
       </FormGroup>
     )

--- a/test/components/__snapshots__/NewStack.js.snap
+++ b/test/components/__snapshots__/NewStack.js.snap
@@ -459,7 +459,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={7}
                     />
                     <p>
                       <span
@@ -475,7 +475,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={7}
                       />
                       <span
                         className="rka-input-range-max"
@@ -510,7 +510,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={76}
                     />
                     <p>
                       <span
@@ -526,7 +526,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={76}
                       />
                       <span
                         className="rka-input-range-max"
@@ -561,7 +561,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={80}
                     />
                     <p>
                       <span
@@ -577,7 +577,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={80}
                       />
                       <span
                         className="rka-input-range-max"
@@ -633,7 +633,7 @@ exports[`NewStack does render with stackOptions 1`] = `
                     className="rka-checkbox is-disabled"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="rka-checkbox-input"
                       disabled={false}
                       name="interlacing.mode"
@@ -913,7 +913,7 @@ exports[`NewStack does render with stacks 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={7}
                     />
                     <p>
                       <span
@@ -929,7 +929,7 @@ exports[`NewStack does render with stacks 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={7}
                       />
                       <span
                         className="rka-input-range-max"
@@ -964,7 +964,7 @@ exports[`NewStack does render with stacks 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={76}
                     />
                     <p>
                       <span
@@ -980,7 +980,7 @@ exports[`NewStack does render with stacks 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={76}
                       />
                       <span
                         className="rka-input-range-max"
@@ -1015,7 +1015,7 @@ exports[`NewStack does render with stacks 1`] = `
                       onChange={[Function]}
                       placeholder={undefined}
                       type="range"
-                      value={undefined}
+                      value={80}
                     />
                     <p>
                       <span
@@ -1031,7 +1031,7 @@ exports[`NewStack does render with stacks 1`] = `
                         placeholder={undefined}
                         size={5}
                         type="text"
-                        value={undefined}
+                        value={80}
                       />
                       <span
                         className="rka-input-range-max"
@@ -1087,7 +1087,7 @@ exports[`NewStack does render with stacks 1`] = `
                     className="rka-checkbox is-disabled"
                   >
                     <input
-                      checked={false}
+                      checked={true}
                       className="rka-checkbox-input"
                       disabled={false}
                       name="interlacing.mode"


### PR DESCRIPTION
Some sub components (usually Compression) of the Options component
switched between controlled and uncontrolled components during the
lifetime of them. This happened because in the NewStack constructor the
initial setting of options was done in a wrong way, resulting in
initially an unset default value for certain options.

Additionally this moves the `ajv` somewhere so that it only needs to be
instantiated once.