### PR TITLE
Fix stats sorting and therefore calculation of totals

### DIFF
--- a/test/components/dashboard/fixtures/january.json
+++ b/test/components/dashboard/fixtures/january.json
@@ -1,0 +1,113 @@
+{
+  "space_in_bytes": [
+    {
+      "timestamp": "2018-01-16T00:00:00+00:00",
+      "value": 95833764,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-15T00:00:00+00:00",
+      "value": 0,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-14T00:00:00+00:00",
+      "value": 196324703,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-13T00:00:00+00:00",
+      "value": 196324703,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-12T00:00:00+00:00",
+      "value": 196324703,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-11T00:00:00+00:00",
+      "value": 196339255,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-10T00:00:00+00:00",
+      "value": 0,
+      "unit": "Bytes"
+    },
+    {
+      "timestamp": "2018-01-09T00:00:00+00:00",
+      "value": 0,
+      "unit": "Bytes"
+    }
+  ],
+  "number_of_files": [
+    {
+      "timestamp": "2018-01-16T00:00:00+00:00",
+      "value": 353,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-15T00:00:00+00:00",
+      "value": 0,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-14T00:00:00+00:00",
+      "value": 210,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-13T00:00:00+00:00",
+      "value": 210,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-12T00:00:00+00:00",
+      "value": 210,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-11T00:00:00+00:00",
+      "value": 211,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-10T00:00:00+00:00",
+      "value": 0,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-09T00:00:00+00:00",
+      "value": 0,
+      "unit": null
+    }
+  ],
+  "bytes_downloaded": [
+    {
+      "timestamp": "2018-01-16T00:00:00+00:00",
+      "value": 3144460,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-15T00:00:00+00:00",
+      "value": 117534504,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-13T00:00:00+00:00",
+      "value": 1427623,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-12T00:00:00+00:00",
+      "value": 211162190,
+      "unit": null
+    },
+    {
+      "timestamp": "2018-01-11T00:00:00+00:00",
+      "value": 51633090,
+      "unit": null
+    }
+  ]
+}

--- a/test/components/dashboard/graphdata.js
+++ b/test/components/dashboard/graphdata.js
@@ -1,0 +1,136 @@
+/**
+ * graphdata tests
+ */
+
+import getStats from '../../../src/components/dashboard/graphdata'
+import january from './fixtures/january'
+
+// monkey patch Date.prototype.toLocaleDateString() to always use the same locale regardless which env it's run in.
+const toLocaleDateString = global.Date.prototype.toLocaleDateString
+global.Date.prototype.toLocaleDateString = function () {
+  return toLocaleDateString.apply(this, ['en'])
+}
+
+test('calculates stats correctly', () => {
+  const from = '2017-12-16'
+  const to = '2018-01-17'
+
+  const {stats, totals, symbols} = getStats(from, to, january)
+
+  expect(totals).toEqual({
+    traffic: 367,
+    space: 91,
+    files: 353
+  })
+  expect(symbols).toEqual({
+    traffic: 'MB',
+    space: 'MB'
+  })
+
+  expect(stats).toEqual({
+    traffic: [
+      {y: 0, name: '12/16/2017'},
+      {y: 0, name: '12/17/2017'},
+      {y: 0, name: '12/18/2017'},
+      {y: 0, name: '12/19/2017'},
+      {y: 0, name: '12/20/2017'},
+      {y: 0, name: '12/21/2017'},
+      {y: 0, name: '12/22/2017'},
+      {y: 0, name: '12/23/2017'},
+      {y: 0, name: '12/24/2017'},
+      {y: 0, name: '12/25/2017'},
+      {y: 0, name: '12/26/2017'},
+      {y: 0, name: '12/27/2017'},
+      {y: 0, name: '12/28/2017'},
+      {y: 0, name: '12/29/2017'},
+      {y: 0, name: '12/30/2017'},
+      {y: 0, name: '12/31/2017'},
+      {y: 0, name: '1/1/2018'},
+      {y: 0, name: '1/2/2018'},
+      {y: 0, name: '1/3/2018'},
+      {y: 0, name: '1/4/2018'},
+      {y: 0, name: '1/5/2018'},
+      {y: 0, name: '1/6/2018'},
+      {y: 0, name: '1/7/2018'},
+      {y: 0, name: '1/8/2018'},
+      {y: 0, name: '1/9/2018'},
+      {y: 0, name: '1/10/2018'},
+      {y: 49.24, name: '1/11/2018'},
+      {y: 201.38, name: '1/12/2018'},
+      {y: 1.36, name: '1/13/2018'},
+      {y: 0, name: '1/14/2018'},
+      {y: 112.09, name: '1/15/2018'},
+      {y: 3, name: '1/16/2018'},
+      {y: 0, name: '1/17/2018'}
+    ],
+    space: [
+      {y: 0, name: '12/16/2017'},
+      {y: 0, name: '12/17/2017'},
+      {y: 0, name: '12/18/2017'},
+      {y: 0, name: '12/19/2017'},
+      {y: 0, name: '12/20/2017'},
+      {y: 0, name: '12/21/2017'},
+      {y: 0, name: '12/22/2017'},
+      {y: 0, name: '12/23/2017'},
+      {y: 0, name: '12/24/2017'},
+      {y: 0, name: '12/25/2017'},
+      {y: 0, name: '12/26/2017'},
+      {y: 0, name: '12/27/2017'},
+      {y: 0, name: '12/28/2017'},
+      {y: 0, name: '12/29/2017'},
+      {y: 0, name: '12/30/2017'},
+      {y: 0, name: '12/31/2017'},
+      {y: 0, name: '1/1/2018'},
+      {y: 0, name: '1/2/2018'},
+      {y: 0, name: '1/3/2018'},
+      {y: 0, name: '1/4/2018'},
+      {y: 0, name: '1/5/2018'},
+      {y: 0, name: '1/6/2018'},
+      {y: 0, name: '1/7/2018'},
+      {y: 0, name: '1/8/2018'},
+      {y: 0, name: '1/9/2018'},
+      {y: 0, name: '1/10/2018'},
+      {y: 187.24, name: '1/11/2018'},
+      {y: 187.23, name: '1/12/2018'},
+      {y: 187.23, name: '1/13/2018'},
+      {y: 187.23, name: '1/14/2018'},
+      {y: 0, name: '1/15/2018'},
+      {y: 91.39, name: '1/16/2018'},
+      {y: 0, name: '1/17/2018'}],
+    files: [
+      {y: 0, name: '12/16/2017'},
+      {y: 0, name: '12/17/2017'},
+      {y: 0, name: '12/18/2017'},
+      {y: 0, name: '12/19/2017'},
+      {y: 0, name: '12/20/2017'},
+      {y: 0, name: '12/21/2017'},
+      {y: 0, name: '12/22/2017'},
+      {y: 0, name: '12/23/2017'},
+      {y: 0, name: '12/24/2017'},
+      {y: 0, name: '12/25/2017'},
+      {y: 0, name: '12/26/2017'},
+      {y: 0, name: '12/27/2017'},
+      {y: 0, name: '12/28/2017'},
+      {y: 0, name: '12/29/2017'},
+      {y: 0, name: '12/30/2017'},
+      {y: 0, name: '12/31/2017'},
+      {y: 0, name: '1/1/2018'},
+      {y: 0, name: '1/2/2018'},
+      {y: 0, name: '1/3/2018'},
+      {y: 0, name: '1/4/2018'},
+      {y: 0, name: '1/5/2018'},
+      {y: 0, name: '1/6/2018'},
+      {y: 0, name: '1/7/2018'},
+      {y: 0, name: '1/8/2018'},
+      {y: 0, name: '1/9/2018'},
+      {y: 0, name: '1/10/2018'},
+      {y: 211, name: '1/11/2018'},
+      {y: 210, name: '1/12/2018'},
+      {y: 210, name: '1/13/2018'},
+      {y: 210, name: '1/14/2018'},
+      {y: 0, name: '1/15/2018'},
+      {y: 353, name: '1/16/2018'},
+      {y: 0, name: '1/17/2018'}
+    ]
+  })
+})


### PR DESCRIPTION
Make sure the stats are sorted in the right way from the beginning on
instead of relying on the backend to deliver it in some form. We'd
anyway need to re-sort it to be correct (that's why there was the call
to `timestamps.reverse()`), so this fixes it to be correct at the very
start.

Additionally the test ensures we actually get what we want.