### PR TITLE
feat: TOTP (MFA) support for API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2026-07-11
+
+### Added
+
+- TOTP (MFA) support for Api Keys:
+  - Progressive login flow that asks for a TOTP code when the used Api Key requires MFA, and runs the TOTP enrollment when a pre-flagged key has no TOTP set up yet
+  - Two-factor section on the Api Keys page to set up / disable TOTP (with QR code) and a per-key "Require MFA" toggle, plus a "Require MFA" option when creating a key
+  - `REACT_APP_API_HOST` env var to point the dashboard at a non-production rokka API (for local development)
+- Requires `rokka` SDK 4.2.0 (MFA endpoints, `totp` token param)
+
+### Changed
+
+- `login()` now mints the JWT token explicitly (so MFA errors from the token endpoint are visible instead of being swallowed by the implicit token refresh)
+
 ## 2026-02-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "moment": "^2.29.4",
     "prettier": "^3.8.1",
     "prop-types": "^15.7.2",
+    "qrcode.react": "^3.2.0",
     "react": "^16.14.0",
     "react-calendar-component": "^2.0.0",
     "react-click-outside": "^3.0.1",
@@ -43,7 +44,7 @@
     "react-tabs": "^4.2.1",
     "react-test-renderer": "^16.14.0",
     "react-transition-group": "^4.4.5",
-    "rokka": "^4.1.0",
+    "rokka": "^4.2.0",
     "sass": "^1.57.0"
   },
   "scripts": {

--- a/src/components/ApikeyRow.js
+++ b/src/components/ApikeyRow.js
@@ -24,9 +24,41 @@ class ApikeyRow extends PureComponent {
         this.props.updateKeys()
       })
       .catch((err) => {
-        alert("Api Key deletion didn't work:" + err.body.error.message)
+        alert("Api Key deletion didn't work:" + this.errorMessage(err))
       })
   }
+
+  errorMessage = (err) => {
+    const error = err && err.body && err.body.error
+    return typeof error === 'string' ? error : (error && error.message) || 'unknown error'
+  }
+
+  isLegacyKey = () => {
+    // legacy (pre-2021) keys have their created date not set and can't be MFA-flagged
+    return !this.props.apiKey.created
+  }
+
+  toggleRequiresMfa = () => {
+    const { apiKey, currentKeyId } = this.props
+    const enabling = !apiKey.requires_mfa
+    if (
+      enabling &&
+      apiKey.id === currentKeyId &&
+      !window.confirm(
+        'This is the Api Key of your current session. Once it requires MFA, your next ' +
+          'login with it will ask for a TOTP code (your current session keeps working). Continue?',
+      )
+    ) {
+      return
+    }
+    rokka()
+      .user.patchApiKey(apiKey.id, { requires_mfa: enabling })
+      .then(() => this.props.updateKeys())
+      .catch((err) => {
+        alert("Changing the Api Key didn't work:" + this.errorMessage(err))
+      })
+  }
+
   render() {
     return (
       <tr key={this.props.apiKey.id}>
@@ -36,6 +68,20 @@ class ApikeyRow extends PureComponent {
         <td>{this.props.apiKey.comment}</td>
         <td>{formatDate(this.props.apiKey.created, 'Before December 2021')}</td>
         <td>{formatDate(this.props.apiKey.accessed, 'Before December 2021')}</td>
+        <td>
+          {this.isLegacyKey() ? (
+            <span className="rka-mfa-status rka-mfa-status-none">n/a</span>
+          ) : (
+            <label>
+              <input
+                type="checkbox"
+                checked={!!this.props.apiKey.requires_mfa}
+                onChange={this.toggleRequiresMfa}
+              />{' '}
+              Require MFA
+            </label>
+          )}
+        </td>
         <td>
           {this.props.apiKey.id === this.props.currentKeyId ? (
             <>

--- a/src/components/ApikeyRow.test.js
+++ b/src/components/ApikeyRow.test.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import ApikeyRow from './ApikeyRow'
+import rokka from '../rokka'
+
+const mockPatchApiKey = jest.fn().mockResolvedValue({ body: {} })
+
+jest.mock('../rokka', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ user: { patchApiKey: mockPatchApiKey } })),
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockPatchApiKey.mockResolvedValue({ body: {} })
+  rokka.mockReturnValue({ user: { patchApiKey: mockPatchApiKey } })
+})
+
+const renderRow = (apiKey, currentKeyId = 'other') => {
+  const updateKeys = jest.fn()
+  let component
+  act(() => {
+    component = renderer.create(
+      <table>
+        <tbody>
+          <ApikeyRow apiKey={apiKey} currentKeyId={currentKeyId} updateKeys={updateKeys} />
+        </tbody>
+      </table>,
+    )
+  })
+  return { component, updateKeys }
+}
+
+test('toggling requires_mfa patches the key', async () => {
+  const { component, updateKeys } = renderRow({
+    id: 'key1',
+    created: '2026-01-01T00:00:00+00:00',
+    requires_mfa: false,
+  })
+  const checkbox = component.root.findByType('input')
+  await act(async () => {
+    checkbox.props.onChange()
+  })
+  expect(mockPatchApiKey).toHaveBeenCalledWith('key1', { requires_mfa: true })
+  expect(updateKeys).toHaveBeenCalled()
+})
+
+test('flagging the current key asks for confirmation', async () => {
+  const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false)
+  const { component } = renderRow(
+    { id: 'currentkey', created: '2026-01-01T00:00:00+00:00', requires_mfa: false },
+    'currentkey',
+  )
+  const checkbox = component.root.findByType('input')
+  await act(async () => {
+    checkbox.props.onChange()
+  })
+  expect(confirmSpy).toHaveBeenCalled()
+  expect(mockPatchApiKey).not.toHaveBeenCalled()
+  confirmSpy.mockRestore()
+})
+
+test('legacy keys (no created date) show n/a and no toggle', () => {
+  const { component } = renderRow({ id: 'legacy', requires_mfa: false })
+  expect(component.root.findAllByType('input')).toHaveLength(0)
+  const na = component.root.findByProps({ className: 'rka-mfa-status rka-mfa-status-none' })
+  expect(na.props.children).toBe('n/a')
+})

--- a/src/components/Apikeys.js
+++ b/src/components/Apikeys.js
@@ -4,6 +4,9 @@ import { authRequired } from '../utils/auth'
 import BaseLayout from './layouts/BaseLayout'
 import rokka from '../rokka'
 import ApikeyRow from './ApikeyRow'
+import Modal from './Modal'
+import MfaEnrollment from './MfaEnrollment'
+import { classifyMfaError, TOTP_RATE_LIMITED } from '../utils/mfaErrors'
 
 const DEFAULT_STATE = {
   loading: true,
@@ -11,7 +14,13 @@ const DEFAULT_STATE = {
   data: [],
   showCreate: false,
   commentValue: '',
+  requiresMfaValue: false,
   newApiKey: null,
+  mfa: null, // {state, confirmed}
+  showMfaSetup: false,
+  showMfaDisable: false,
+  disableCode: '',
+  disableMessage: null,
 }
 
 class Apikeys extends PureComponent {
@@ -22,6 +31,18 @@ class Apikeys extends PureComponent {
 
   componentDidMount() {
     this.getKeys()
+    this.getMfaStatus()
+  }
+
+  getMfaStatus = () => {
+    rokka()
+      .user.getMfaTotp()
+      .then(({ body }) => {
+        this.setState({ mfa: body })
+      })
+      .catch(() => {
+        this.setState({ mfa: { state: 'unavailable' } })
+      })
   }
 
   getTable = (data) => {
@@ -33,6 +54,7 @@ class Apikeys extends PureComponent {
             <th>Comment</th>
             <th>Created</th>
             <th>Last Access (updated every 24h)</th>
+            <th>MFA</th>
             <th> </th>
           </tr>
           {data.map((key) => {
@@ -72,22 +94,144 @@ class Apikeys extends PureComponent {
   showCreateNewKey = () => {
     if (this.state.showCreate) {
       rokka()
-        .user.addApiKey(this.state.commentValue)
+        .user.addApiKey(this.state.commentValue, { requires_mfa: this.state.requiresMfaValue })
         .then(({ body }) => {
-          this.setState({ showCreate: false, commentValue: '', newApiKey: body.api_key })
+          this.setState({
+            showCreate: false,
+            commentValue: '',
+            requiresMfaValue: false,
+            newApiKey: body.api_key,
+          })
 
           this.getKeys()
         })
         .catch((err) => {
-          this.setState({ showCreate: false, commentValue: '' })
-          alert("Api Key creation didn't work:" + err.body.error.message)
+          this.setState({ showCreate: false, commentValue: '', requiresMfaValue: false })
+          alert("Api Key creation didn't work:" + this.errorMessage(err))
         })
     } else {
       this.setState({ showCreate: true })
     }
   }
 
-  createNewKey = () => {}
+  errorMessage = (err) => {
+    const error = err && err.body && err.body.error
+    return typeof error === 'string' ? error : (error && error.message) || 'unknown error'
+  }
+
+  onDisableMfa = (e) => {
+    e.preventDefault()
+    const code = this.state.disableCode.trim()
+    if (!code) {
+      return
+    }
+    rokka()
+      .user.disableMfaTotp(code)
+      .then(() => {
+        // disabling also unflags all keys, so refresh both
+        this.setState({ showMfaDisable: false, disableCode: '', disableMessage: null })
+        this.getMfaStatus()
+        this.getKeys()
+      })
+      .catch((err) => {
+        const kind = classifyMfaError(err)
+        this.setState({
+          disableCode: '',
+          disableMessage:
+            kind === TOTP_RATE_LIMITED
+              ? 'Too many attempts. Please wait a moment and try again.'
+              : 'Wrong code. Please try again.',
+        })
+      })
+  }
+
+  renderMfaSection = () => {
+    const mfa = this.state.mfa
+    if (!mfa) {
+      return null
+    }
+    const state = mfa.state
+    return (
+      <div key={'mfa'} className="section rka-box no-min-height">
+        <h2 className={'rka-h2 mb-md'}>Two-factor authentication (MFA)</h2>
+        {state === 'unavailable' && <div>MFA status is currently unavailable.</div>}
+        {state === 'active' && (
+          <>
+            <div className={'mb-md'}>
+              <span className="rka-mfa-status rka-mfa-status-active">active</span> TOTP is set up
+              for your user. Api Keys that require MFA can be exchanged for a token with a code.
+            </div>
+            <button
+              className="rka-button rka-button-secondary"
+              onClick={() => this.setState({ showMfaDisable: true, disableMessage: null })}
+            >
+              Disable MFA
+            </button>
+          </>
+        )}
+        {(state === 'none' || state === 'pending') && (
+          <>
+            <div className={'mb-md'}>
+              <span className={'rka-mfa-status rka-mfa-status-' + state}>{state}</span>{' '}
+              {state === 'pending'
+                ? 'You started setting up TOTP but did not confirm it yet.'
+                : 'You have not set up TOTP yet. Set it up to protect Api Keys with a second factor.'}
+            </div>
+            <button
+              className="rka-button rka-button-brand"
+              onClick={() => this.setState({ showMfaSetup: true })}
+            >
+              {state === 'pending' ? 'Finish MFA setup' : 'Set up MFA'}
+            </button>
+          </>
+        )}
+        {this.state.showMfaSetup && (
+          <Modal onClose={() => this.setState({ showMfaSetup: false })}>
+            <MfaEnrollment
+              client={rokka()}
+              onEnrolled={() => {
+                this.setState({ showMfaSetup: false })
+                this.getMfaStatus()
+                this.getKeys()
+              }}
+              onCancel={() => this.setState({ showMfaSetup: false })}
+            />
+          </Modal>
+        )}
+        {this.state.showMfaDisable && (
+          <Modal onClose={() => this.setState({ showMfaDisable: false, disableCode: '' })}>
+            <form onSubmit={this.onDisableMfa}>
+              <h3 className="rka-h3">Disable two-factor authentication</h3>
+              <p>Enter a current code to confirm. This also removes MFA from all your Api Keys.</p>
+              <div className="rka-form-group">
+                <label className="rka-label" htmlFor="mfa-disable-code">
+                  Verification code
+                </label>
+                <input
+                  className="rka-input-txt"
+                  type="text"
+                  id="mfa-disable-code"
+                  name="disableCode"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                  autoFocus
+                  value={this.state.disableCode}
+                  onChange={(e) => this.setState({ disableCode: e.currentTarget.value.trim() })}
+                />
+              </div>
+              {this.state.disableMessage && (
+                <p className="rka-mfa-error">{this.state.disableMessage}</p>
+              )}
+              <button className="rka-button rka-button-brand" type="submit">
+                Disable MFA
+              </button>
+            </form>
+          </Modal>
+        )}
+      </div>
+    )
+  }
 
   render() {
     return (
@@ -100,6 +244,7 @@ class Apikeys extends PureComponent {
           </div>
           <div>If the list is empty, you don't have enough rights to see it.</div>
         </div>
+        {this.renderMfaSection()}
         <div key={'table'} className="section rka-box no-min-height rka-table-apikeys">
           {this.getTable(this.state.data)}
         </div>
@@ -126,9 +271,32 @@ class Apikeys extends PureComponent {
           )}
 
           {this.state.showCreate && (
+            <div className="mb-sm">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={this.state.requiresMfaValue}
+                  onChange={(e) => this.setState({ requiresMfaValue: e.currentTarget.checked })}
+                />{' '}
+                Require MFA for this key
+              </label>
+              {this.state.requiresMfaValue &&
+                this.state.mfa &&
+                this.state.mfa.state !== 'active' && (
+                  <div className="rka-mfa-error">
+                    You have not set up TOTP yet — this key will only be usable to set up TOTP until
+                    you complete enrollment.
+                  </div>
+                )}
+            </div>
+          )}
+
+          {this.state.showCreate && (
             <button
               className="rka-button rka-button-secondary mr-md"
-              onClick={() => this.setState({ showCreate: false, commentValue: '' })}
+              onClick={() =>
+                this.setState({ showCreate: false, commentValue: '', requiresMfaValue: false })
+              }
             >
               Cancel
             </button>
@@ -162,4 +330,5 @@ Apikeys.propTypes = {
   auth: PropTypes.object,
 }
 
+export { Apikeys }
 export default authRequired(Apikeys)

--- a/src/components/Apikeys.test.js
+++ b/src/components/Apikeys.test.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import { Apikeys } from './Apikeys'
+import rokka from '../rokka'
+
+jest.mock('../rokka')
+jest.mock('../state')
+// render only the children, skip the full BaseLayout/Sidebar chrome
+jest.mock('./layouts/BaseLayout', () => ({ children }) => <div>{children}</div>)
+
+const flush = () => act(async () => {})
+
+const mockUser = (mfaState) => ({
+  user: {
+    getCurrentApiKey: jest.fn().mockResolvedValue({ body: { id: 'key1' } }),
+    listApiKeys: jest.fn().mockResolvedValue({
+      body: [{ id: 'key1', created: '2026-01-01T00:00:00+00:00', requires_mfa: false }],
+    }),
+    getMfaTotp: jest.fn().mockResolvedValue({ body: { state: mfaState } }),
+    disableMfaTotp: jest.fn().mockResolvedValue({}),
+  },
+})
+
+const props = {
+  router: { history: { push: () => {} } },
+  auth: { organization: 'org', apiToken: 'token' },
+}
+
+const renderApikeys = async () => {
+  let component
+  await act(async () => {
+    component = renderer.create(<Apikeys {...props} />)
+  })
+  await flush()
+  return component
+}
+
+test('shows the set-up button when MFA state is none', async () => {
+  rokka.mockReturnValue(mockUser('none'))
+  const component = await renderApikeys()
+  const buttons = component.root.findAllByType('button').map((b) => b.props.children)
+  expect(buttons).toContain('Set up MFA')
+})
+
+test('shows the disable button when MFA is active', async () => {
+  rokka.mockReturnValue(mockUser('active'))
+  const component = await renderApikeys()
+  const buttons = component.root.findAllByType('button').map((b) => b.props.children)
+  expect(buttons).toContain('Disable MFA')
+})

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -2,7 +2,16 @@ import React, { PureComponent } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import FramelessLayout from './layouts/FramelessLayout'
 import Spinner from './Spinner'
+import MfaEnrollment from './MfaEnrollment'
 import { login } from '../state'
+import { createApiKeyClient } from '../rokka'
+import {
+  classifyMfaError,
+  MFA_REQUIRED,
+  MFA_ENROLLMENT_REQUIRED,
+  TOTP_INVALID,
+  TOTP_RATE_LIMITED,
+} from '../utils/mfaErrors'
 import cx from 'classnames'
 
 class Login extends PureComponent {
@@ -14,15 +23,32 @@ class Login extends PureComponent {
       apiKey: null,
       showLoader: false,
       showTransition: false,
+      step: 'credentials', // credentials | totp | enrolling
+      totp: '',
+      mfaMessage: null,
     }
 
     this.onLogin = this.onLogin.bind(this)
+    this.onSubmitTotp = this.onSubmitTotp.bind(this)
+    this.doLogin = this.doLogin.bind(this)
   }
 
   onLogin(e) {
     e.preventDefault()
+    this.doLogin()
+  }
 
-    this.setState({ showLoader: true })
+  onSubmitTotp(e) {
+    e.preventDefault()
+    const totp = this.state.totp.trim()
+    if (!totp) {
+      return
+    }
+    this.doLogin(totp)
+  }
+
+  doLogin(totp) {
+    this.setState({ showLoader: true, mfaMessage: null })
 
     const successCb = (done) => {
       this.setState({
@@ -32,8 +58,30 @@ class Login extends PureComponent {
       setTimeout(done, 900)
     }
 
-    login(this.state.organization, this.state.apiKey, successCb).catch(() => {
-      this.setState({ showLoader: false })
+    login(this.state.organization, this.state.apiKey, successCb, totp).catch((err) => {
+      const kind = classifyMfaError(err)
+      if (kind === MFA_REQUIRED) {
+        this.setState({ step: 'totp', totp: '', showLoader: false, mfaMessage: null })
+      } else if (kind === TOTP_INVALID) {
+        this.setState({
+          step: 'totp',
+          totp: '',
+          showLoader: false,
+          mfaMessage: 'Invalid or already used code. Please try again.',
+        })
+      } else if (kind === TOTP_RATE_LIMITED) {
+        this.setState({
+          step: 'totp',
+          totp: '',
+          showLoader: false,
+          mfaMessage: 'Too many attempts. Please wait a moment and try again.',
+        })
+      } else if (kind === MFA_ENROLLMENT_REQUIRED) {
+        this.setState({ step: 'enrolling', showLoader: false })
+      } else {
+        // a non-MFA error, the global alert (set in state.login) handles it
+        this.setState({ showLoader: false })
+      }
     })
   }
 
@@ -45,6 +93,117 @@ class Login extends PureComponent {
     this.setState({
       [name]: value,
     })
+  }
+
+  renderCredentials() {
+    return (
+      <form onSubmit={this.onLogin}>
+        <div className="rka-form-group">
+          <label className="rka-label" htmlFor="organization">
+            Organization
+          </label>
+          <input
+            className="rka-input-txt"
+            type="text"
+            id="organization"
+            name="organization"
+            defaultValue={this.state.organization}
+            onChange={(e) => this.onChange(e)}
+          />
+        </div>
+        <div className="rka-form-group">
+          <label className="rka-label" htmlFor="apiKey">
+            Api Key
+          </label>
+          <input
+            className="rka-input-txt"
+            type="password"
+            id="apiKey"
+            name="apiKey"
+            defaultValue={this.state.apiKey}
+            onChange={(e) => this.onChange(e)}
+          />
+        </div>
+        <button
+          className={cx('rka-button rka-button-brand mt-sm', {
+            disabled: this.state.showLoader,
+          })}
+          type="submit"
+        >
+          {this.state.showLoader ? (
+            <div className="sk-cube-small sk-cube-white">
+              <Spinner />
+            </div>
+          ) : (
+            'Login'
+          )}
+        </button>
+      </form>
+    )
+  }
+
+  renderTotp() {
+    return (
+      <form onSubmit={this.onSubmitTotp}>
+        <h3 className="rka-h3">Two-factor authentication</h3>
+        <p>Enter the current code from your authenticator app.</p>
+        <div className="rka-form-group">
+          <label className="rka-label" htmlFor="totp">
+            Verification code
+          </label>
+          <input
+            className="rka-input-txt"
+            type="text"
+            id="totp"
+            name="totp"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            maxLength={6}
+            autoFocus
+            value={this.state.totp}
+            onChange={(e) => this.onChange(e)}
+          />
+        </div>
+        {this.state.mfaMessage && <p className="rka-mfa-error">{this.state.mfaMessage}</p>}
+        <div className="rka-mfa-actions">
+          <button
+            className={cx('rka-button rka-button-brand', { disabled: this.state.showLoader })}
+            type="submit"
+          >
+            {this.state.showLoader ? (
+              <div className="sk-cube-small sk-cube-white">
+                <Spinner />
+              </div>
+            ) : (
+              'Verify'
+            )}
+          </button>
+          <button
+            className="rka-button rka-button-secondary"
+            type="button"
+            onClick={() => this.setState({ step: 'credentials', totp: '', mfaMessage: null })}
+          >
+            Back
+          </button>
+        </div>
+      </form>
+    )
+  }
+
+  renderStep() {
+    if (this.state.step === 'totp') {
+      return this.renderTotp()
+    }
+    if (this.state.step === 'enrolling') {
+      return (
+        <MfaEnrollment
+          client={createApiKeyClient(this.state.apiKey)}
+          onEnrolled={(code) => this.doLogin(code)}
+          onCancel={() => this.setState({ step: 'credentials', mfaMessage: null })}
+        />
+      )
+    }
+    return this.renderCredentials()
   }
 
   render() {
@@ -64,50 +223,7 @@ class Login extends PureComponent {
                 </div>
               </div>
               <div className="col-md-7">
-                <div className="rka-login-form-container">
-                  <form onSubmit={this.onLogin}>
-                    <div className="rka-form-group">
-                      <label className="rka-label" htmlFor="organization">
-                        Organization
-                      </label>
-                      <input
-                        className="rka-input-txt"
-                        type="text"
-                        id="organization"
-                        name="organization"
-                        defaultValue={this.state.organization}
-                        onChange={(e) => this.onChange(e)}
-                      />
-                    </div>
-                    <div className="rka-form-group">
-                      <label className="rka-label" htmlFor="apiKey">
-                        Api Key
-                      </label>
-                      <input
-                        className="rka-input-txt"
-                        type="password"
-                        id="apiKey"
-                        name="apiKey"
-                        defaultValue={this.state.apiKey}
-                        onChange={(e) => this.onChange(e)}
-                      />
-                    </div>
-                    <button
-                      className={cx('rka-button rka-button-brand mt-sm', {
-                        disabled: this.state.showLoader,
-                      })}
-                      type="submit"
-                    >
-                      {this.state.showLoader ? (
-                        <div className="sk-cube-small sk-cube-white">
-                          <Spinner />
-                        </div>
-                      ) : (
-                        'Login'
-                      )}
-                    </button>
-                  </form>
-                </div>
+                <div className="rka-login-form-container">{this.renderStep()}</div>
               </div>
             </div>
           </div>

--- a/src/components/Login.test.js
+++ b/src/components/Login.test.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import Login from './Login'
+import { login } from '../state'
+import { createApiKeyClient } from '../rokka'
+
+jest.mock('../state', () => ({
+  login: jest.fn(),
+}))
+jest.mock('../rokka', () => ({
+  // setupMfaTotp stays pending so MfaEnrollment keeps its loading state
+  createApiKeyClient: jest.fn(() => ({
+    user: { setupMfaTotp: () => new Promise(() => {}) },
+  })),
+}))
+// keep MfaEnrollment out of this unit test, it has its own test file
+jest.mock('./MfaEnrollment', () => () => <div className="rka-mfa-enrollment-stub" />)
+
+const flush = () => act(async () => {})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+test('Login renders the credentials step', () => {
+  const component = renderer.create(<Login />)
+  expect(component.root.findByProps({ id: 'organization' })).toBeTruthy()
+  expect(component.root.findByProps({ id: 'apiKey' })).toBeTruthy()
+})
+
+test('Login switches to the totp step on mfa_required', async () => {
+  login.mockRejectedValue({ body: { error: 'mfa_required' } })
+  const component = renderer.create(<Login />)
+
+  const form = component.root.findByType('form')
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: () => {} })
+  })
+  await flush()
+
+  expect(component.root.findByProps({ id: 'totp' })).toBeTruthy()
+})
+
+test('Login shows a rate limit message on totp_rate_limited', async () => {
+  login.mockRejectedValue({ body: { error: 'totp_rate_limited' } })
+  const component = renderer.create(<Login />)
+
+  const form = component.root.findByType('form')
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: () => {} })
+  })
+  await flush()
+
+  const error = component.root.findByProps({ className: 'rka-mfa-error' })
+  expect(error.props.children).toMatch(/too many attempts/i)
+})
+
+test('Login shows the enrollment wizard on mfa_enrollment_required', async () => {
+  login.mockRejectedValue({ body: { error: 'mfa_enrollment_required' } })
+  const component = renderer.create(<Login />)
+
+  const form = component.root.findByType('form')
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: () => {} })
+  })
+  await flush()
+
+  expect(createApiKeyClient).toHaveBeenCalled()
+  expect(component.root.findByProps({ className: 'rka-mfa-enrollment-stub' })).toBeTruthy()
+})

--- a/src/components/MfaEnrollment.js
+++ b/src/components/MfaEnrollment.js
@@ -1,0 +1,181 @@
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import CopyToClipboard from 'react-copy-to-clipboard'
+import cx from 'classnames'
+import Spinner from './Spinner'
+import { classifyMfaError, TOTP_RATE_LIMITED } from '../utils/mfaErrors'
+
+/**
+ * TOTP (MFA) enrollment wizard. Container-agnostic: rendered inline in the
+ * login flow (with an Api-Key client) and inside a Modal on the Apikeys page
+ * (with the normal session client).
+ *
+ * On mount it starts the setup (POST /user/mfa/totp) and shows the QR code +
+ * secret. After the user confirms a code, onEnrolled(code) is called with the
+ * confirmed code, which the caller can reuse once for the token exchange.
+ */
+class MfaEnrollment extends PureComponent {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      phase: 'loading', // loading | secret | error
+      secret: null,
+      provisioningUri: null,
+      code: '',
+      message: null,
+      submitting: false,
+      copied: false,
+    }
+
+    this.onConfirm = this.onConfirm.bind(this)
+  }
+
+  componentDidMount() {
+    this.props.client.user
+      .setupMfaTotp()
+      .then((res) => {
+        this.setState({
+          phase: 'secret',
+          secret: res.body.secret,
+          provisioningUri: res.body.provisioning_uri,
+        })
+      })
+      .catch((err) => {
+        if (err.statusCode === 409) {
+          this.setState({
+            phase: 'error',
+            message: 'Two-factor authentication is already active for your user.',
+          })
+          return
+        }
+        this.setState({
+          phase: 'error',
+          message: 'Could not start the two-factor setup. Please try again.',
+        })
+      })
+  }
+
+  onConfirm(e) {
+    e.preventDefault()
+    const code = this.state.code.trim()
+    if (!code) {
+      return
+    }
+    this.setState({ submitting: true, message: null })
+    this.props.client.user
+      .confirmMfaTotp(code)
+      .then(() => {
+        this.setState({ submitting: false })
+        this.props.onEnrolled(code)
+      })
+      .catch((err) => {
+        const kind = classifyMfaError(err)
+        let message = 'Wrong code. Please try again.'
+        if (kind === TOTP_RATE_LIMITED) {
+          message = 'Too many attempts. Please wait a moment and try again.'
+        } else if (err.statusCode === 409) {
+          message = 'The setup expired. Please reload and start again.'
+        }
+        this.setState({ submitting: false, code: '', message })
+      })
+  }
+
+  render() {
+    const { phase, message, submitting } = this.state
+    const { onCancel } = this.props
+
+    if (phase === 'loading') {
+      return (
+        <div className="rka-mfa-enrollment">
+          <div className="sk-cube-small">
+            <Spinner />
+          </div>
+        </div>
+      )
+    }
+
+    if (phase === 'error') {
+      return (
+        <div className="rka-mfa-enrollment">
+          <p className="rka-mfa-error">{message}</p>
+          {onCancel && (
+            <button className="rka-button rka-button-secondary" onClick={onCancel}>
+              Back
+            </button>
+          )}
+        </div>
+      )
+    }
+
+    return (
+      <div className="rka-mfa-enrollment">
+        <h3 className="rka-h3">Set up two-factor authentication</h3>
+        <p>
+          Scan this QR code with an authenticator app (e.g. Google Authenticator, 1Password), then
+          enter the current code below to activate it.
+        </p>
+        <div className="rka-mfa-qr">
+          <QRCodeSVG value={this.state.provisioningUri} size={192} />
+        </div>
+        <p className="rka-mfa-secret-label">Or enter this secret manually:</p>
+        <div className="rka-mfa-secret">
+          <code>{this.state.secret}</code>
+          <CopyToClipboard text={this.state.secret} onCopy={() => this.setState({ copied: true })}>
+            <button className="rka-button rka-button-secondary rka-button-small" type="button">
+              {this.state.copied ? 'Copied' : 'Copy'}
+            </button>
+          </CopyToClipboard>
+        </div>
+        <form onSubmit={this.onConfirm}>
+          <div className="rka-form-group">
+            <label className="rka-label" htmlFor="mfa-enroll-code">
+              Verification code
+            </label>
+            <input
+              className="rka-input-txt"
+              type="text"
+              id="mfa-enroll-code"
+              name="code"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              autoFocus
+              value={this.state.code}
+              onChange={(e) => this.setState({ code: e.currentTarget.value.trim() })}
+            />
+          </div>
+          {message && <p className="rka-mfa-error">{message}</p>}
+          <div className="rka-mfa-actions">
+            <button
+              className={cx('rka-button rka-button-brand', { disabled: submitting })}
+              type="submit"
+            >
+              {submitting ? (
+                <div className="sk-cube-small sk-cube-white">
+                  <Spinner />
+                </div>
+              ) : (
+                'Activate'
+              )}
+            </button>
+            {onCancel && (
+              <button className="rka-button rka-button-secondary" type="button" onClick={onCancel}>
+                Cancel
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    )
+  }
+}
+
+MfaEnrollment.propTypes = {
+  client: PropTypes.object.isRequired,
+  onEnrolled: PropTypes.func.isRequired,
+  onCancel: PropTypes.func,
+}
+
+export default MfaEnrollment

--- a/src/components/MfaEnrollment.test.js
+++ b/src/components/MfaEnrollment.test.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import MfaEnrollment from './MfaEnrollment'
+
+const flush = () => act(async () => {})
+
+const makeClient = (overrides = {}) => ({
+  user: {
+    setupMfaTotp: jest.fn().mockResolvedValue({
+      body: {
+        secret: 'JBSWY3DPEHPK3PXP',
+        provisioning_uri:
+          'otpauth://totp/rokka%3Auser%40example.com?issuer=rokka&secret=JBSWY3DPEHPK3PXP',
+        state: 'pending',
+      },
+    }),
+    confirmMfaTotp: jest.fn().mockResolvedValue({ body: { state: 'active' } }),
+    ...overrides,
+  },
+})
+
+test('MfaEnrollment shows the secret after setup', async () => {
+  const client = makeClient()
+  let component
+  await act(async () => {
+    component = renderer.create(
+      <MfaEnrollment client={client} onEnrolled={() => {}} onCancel={() => {}} />,
+    )
+  })
+  await flush()
+  expect(client.user.setupMfaTotp).toHaveBeenCalledTimes(1)
+  expect(component.toJSON()).toMatchSnapshot()
+})
+
+test('MfaEnrollment calls onEnrolled with the confirmed code', async () => {
+  const client = makeClient()
+  const onEnrolled = jest.fn()
+  let component
+  await act(async () => {
+    component = renderer.create(
+      <MfaEnrollment client={client} onEnrolled={onEnrolled} onCancel={() => {}} />,
+    )
+  })
+  await flush()
+
+  const input = component.root.findByProps({ id: 'mfa-enroll-code' })
+  act(() => {
+    input.props.onChange({ currentTarget: { value: '123456' } })
+  })
+  const form = component.root.findByType('form')
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: () => {} })
+  })
+
+  expect(client.user.confirmMfaTotp).toHaveBeenCalledWith('123456')
+  expect(onEnrolled).toHaveBeenCalledWith('123456')
+})
+
+test('MfaEnrollment shows a retry message on a wrong code', async () => {
+  const client = makeClient({
+    confirmMfaTotp: jest.fn().mockRejectedValue({ statusCode: 400, body: { message: 'bad' } }),
+  })
+  const onEnrolled = jest.fn()
+  let component
+  await act(async () => {
+    component = renderer.create(
+      <MfaEnrollment client={client} onEnrolled={onEnrolled} onCancel={() => {}} />,
+    )
+  })
+  await flush()
+
+  const input = component.root.findByProps({ id: 'mfa-enroll-code' })
+  act(() => {
+    input.props.onChange({ currentTarget: { value: '000000' } })
+  })
+  const form = component.root.findByType('form')
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: () => {} })
+  })
+
+  expect(onEnrolled).not.toHaveBeenCalled()
+  const error = component.root.findByProps({ className: 'rka-mfa-error' })
+  expect(error.props.children).toMatch(/try again/i)
+})

--- a/src/components/__snapshots__/MfaEnrollment.test.js.snap
+++ b/src/components/__snapshots__/MfaEnrollment.test.js.snap
@@ -1,0 +1,98 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MfaEnrollment shows the secret after setup 1`] = `
+<div
+  className="rka-mfa-enrollment"
+>
+  <h3
+    className="rka-h3"
+  >
+    Set up two-factor authentication
+  </h3>
+  <p>
+    Scan this QR code with an authenticator app (e.g. Google Authenticator, 1Password), then enter the current code below to activate it.
+  </p>
+  <div
+    className="rka-mfa-qr"
+  >
+    <svg
+      height={192}
+      viewBox="0 0 33 33"
+      width={192}
+    >
+      <path
+        d="M0,0 h33v33H0z"
+        fill="#FFFFFF"
+        shapeRendering="crispEdges"
+      />
+      <path
+        d="M0 0h7v1H0zM9 0h2v1H9zM16 0h1v1H16zM19 0h3v1H19zM23 0h2v1H23zM26,0 h7v1H26zM0 1h1v1H0zM6 1h1v1H6zM8 1h2v1H8zM14 1h2v1H14zM17 1h2v1H17zM20 1h3v1H20zM24 1h1v1H24zM26 1h1v1H26zM32,1 h1v1H32zM0 2h1v1H0zM2 2h3v1H2zM6 2h1v1H6zM9 2h1v1H9zM11 2h2v1H11zM14 2h1v1H14zM21 2h4v1H21zM26 2h1v1H26zM28 2h3v1H28zM32,2 h1v1H32zM0 3h1v1H0zM2 3h3v1H2zM6 3h1v1H6zM8 3h3v1H8zM13 3h5v1H13zM19 3h1v1H19zM26 3h1v1H26zM28 3h3v1H28zM32,3 h1v1H32zM0 4h1v1H0zM2 4h3v1H2zM6 4h1v1H6zM10 4h3v1H10zM14 4h1v1H14zM16 4h1v1H16zM19 4h5v1H19zM26 4h1v1H26zM28 4h3v1H28zM32,4 h1v1H32zM0 5h1v1H0zM6 5h1v1H6zM8 5h2v1H8zM14 5h5v1H14zM20 5h3v1H20zM26 5h1v1H26zM32,5 h1v1H32zM0 6h7v1H0zM8 6h1v1H8zM10 6h1v1H10zM12 6h1v1H12zM14 6h1v1H14zM16 6h1v1H16zM18 6h1v1H18zM20 6h1v1H20zM22 6h1v1H22zM24 6h1v1H24zM26,6 h7v1H26zM9 7h1v1H9zM11 7h2v1H11zM19 7h3v1H19zM0 8h5v1H0zM6 8h8v1H6zM15 8h1v1H15zM17 8h1v1H17zM19 8h2v1H19zM24 8h2v1H24zM27 8h1v1H27zM29 8h1v1H29zM31 8h1v1H31zM4 9h2v1H4zM7 9h4v1H7zM13 9h2v1H13zM16 9h1v1H16zM19 9h1v1H19zM21 9h3v1H21zM25 9h2v1H25zM29,9 h4v1H29zM0 10h1v1H0zM2 10h1v1H2zM6 10h1v1H6zM8 10h2v1H8zM12 10h1v1H12zM14 10h3v1H14zM20 10h2v1H20zM28 10h4v1H28zM0 11h1v1H0zM3 11h2v1H3zM7 11h3v1H7zM12 11h1v1H12zM14 11h3v1H14zM20 11h2v1H20zM23 11h2v1H23zM26 11h1v1H26zM28 11h4v1H28zM0 12h1v1H0zM2 12h1v1H2zM5 12h2v1H5zM8 12h2v1H8zM14 12h2v1H14zM17 12h1v1H17zM19 12h1v1H19zM22 12h1v1H22zM25 12h1v1H25zM27 12h3v1H27zM0 13h1v1H0zM4 13h1v1H4zM7 13h1v1H7zM9 13h1v1H9zM13 13h1v1H13zM16 13h1v1H16zM18 13h4v1H18zM23 13h1v1H23zM26 13h2v1H26zM29 13h2v1H29zM32,13 h1v1H32zM0 14h2v1H0zM4 14h1v1H4zM6 14h2v1H6zM12 14h2v1H12zM15 14h2v1H15zM20 14h3v1H20zM25 14h3v1H25zM30 14h2v1H30zM5 15h1v1H5zM10 15h1v1H10zM12 15h1v1H12zM19 15h4v1H19zM25 15h3v1H25zM29 15h2v1H29zM0 16h2v1H0zM6 16h1v1H6zM9 16h4v1H9zM14 16h4v1H14zM19 16h1v1H19zM22 16h1v1H22zM25 16h1v1H25zM28 16h1v1H28zM1 17h1v1H1zM3 17h3v1H3zM8 17h1v1H8zM10 17h1v1H10zM16 17h1v1H16zM19 17h2v1H19zM22 17h2v1H22zM26 17h1v1H26zM31,17 h2v1H31zM0 18h5v1H0zM6 18h2v1H6zM10 18h1v1H10zM13 18h1v1H13zM15 18h1v1H15zM17 18h2v1H17zM20 18h2v1H20zM26 18h2v1H26zM30 18h2v1H30zM2 19h3v1H2zM7 19h4v1H7zM16 19h1v1H16zM18 19h2v1H18zM21 19h1v1H21zM24 19h3v1H24zM30 19h1v1H30zM1 20h1v1H1zM3 20h1v1H3zM5 20h6v1H5zM12 20h1v1H12zM14 20h2v1H14zM17 20h2v1H17zM22 20h1v1H22zM24 20h2v1H24zM28 20h2v1H28zM31 20h1v1H31zM0 21h4v1H0zM5 21h1v1H5zM7 21h2v1H7zM10 21h1v1H10zM14 21h1v1H14zM17 21h1v1H17zM19 21h3v1H19zM26 21h1v1H26zM31,21 h2v1H31zM0 22h1v1H0zM2 22h2v1H2zM5 22h4v1H5zM12 22h2v1H12zM15 22h2v1H15zM21 22h1v1H21zM26 22h1v1H26zM28 22h1v1H28zM31 22h1v1H31zM0 23h1v1H0zM4 23h1v1H4zM12 23h1v1H12zM14 23h2v1H14zM19 23h8v1H19zM28 23h1v1H28zM30,23 h3v1H30zM0 24h1v1H0zM2 24h2v1H2zM6 24h1v1H6zM9 24h2v1H9zM14 24h2v1H14zM17 24h1v1H17zM19 24h1v1H19zM22 24h1v1H22zM24 24h5v1H24zM31,24 h2v1H31zM8 25h1v1H8zM10 25h1v1H10zM14 25h1v1H14zM16 25h1v1H16zM19 25h1v1H19zM23 25h2v1H23zM28 25h2v1H28zM32,25 h1v1H32zM0 26h7v1H0zM8 26h3v1H8zM12 26h7v1H12zM20 26h5v1H20zM26 26h1v1H26zM28 26h2v1H28zM31 26h1v1H31zM0 27h1v1H0zM6 27h1v1H6zM10 27h1v1H10zM14 27h1v1H14zM18 27h1v1H18zM20 27h3v1H20zM24 27h1v1H24zM28 27h1v1H28zM30 27h1v1H30zM32,27 h1v1H32zM0 28h1v1H0zM2 28h3v1H2zM6 28h1v1H6zM8 28h3v1H8zM12 28h1v1H12zM14 28h1v1H14zM17 28h1v1H17zM22 28h1v1H22zM24 28h5v1H24zM31,28 h2v1H31zM0 29h1v1H0zM2 29h3v1H2zM6 29h1v1H6zM8 29h2v1H8zM13 29h2v1H13zM16 29h10v1H16zM27 29h3v1H27zM0 30h1v1H0zM2 30h3v1H2zM6 30h1v1H6zM8 30h3v1H8zM15 30h3v1H15zM21 30h1v1H21zM23 30h2v1H23zM26 30h1v1H26zM29 30h1v1H29zM31 30h1v1H31zM0 31h1v1H0zM6 31h1v1H6zM8 31h2v1H8zM11 31h2v1H11zM14 31h1v1H14zM20 31h2v1H20zM27 31h1v1H27zM29 31h2v1H29zM0 32h7v1H0zM8 32h2v1H8zM13 32h1v1H13zM17 32h1v1H17zM19 32h1v1H19zM22 32h1v1H22zM24 32h2v1H24zM29 32h1v1H29zM31 32h1v1H31z"
+        fill="#000000"
+        shapeRendering="crispEdges"
+      />
+    </svg>
+  </div>
+  <p
+    className="rka-mfa-secret-label"
+  >
+    Or enter this secret manually:
+  </p>
+  <div
+    className="rka-mfa-secret"
+  >
+    <code>
+      JBSWY3DPEHPK3PXP
+    </code>
+    <button
+      className="rka-button rka-button-secondary rka-button-small"
+      onClick={[Function]}
+      type="button"
+    >
+      Copy
+    </button>
+  </div>
+  <form
+    onSubmit={[Function]}
+  >
+    <div
+      className="rka-form-group"
+    >
+      <label
+        className="rka-label"
+        htmlFor="mfa-enroll-code"
+      >
+        Verification code
+      </label>
+      <input
+        autoComplete="one-time-code"
+        autoFocus={true}
+        className="rka-input-txt"
+        id="mfa-enroll-code"
+        inputMode="numeric"
+        maxLength={6}
+        name="code"
+        onChange={[Function]}
+        type="text"
+        value=""
+      />
+    </div>
+    <div
+      className="rka-mfa-actions"
+    >
+      <button
+        className="rka-button rka-button-brand"
+        type="submit"
+      >
+        Activate
+      </button>
+      <button
+        className="rka-button rka-button-secondary"
+        onClick={[Function]}
+        type="button"
+      >
+        Cancel
+      </button>
+    </div>
+  </form>
+</div>
+`;

--- a/src/rokka.js
+++ b/src/rokka.js
@@ -1,6 +1,9 @@
 import rokka from 'rokka'
 
-let client = rokka()
+// mainly for local development against a local rokka-api
+const apiHost = process.env.REACT_APP_API_HOST || undefined
+
+let client = rokka({ apiHost })
 const max_age = 3600 * 72
 export const ROKKA_DASHBOARD_TOKEN = 'rokka-dashboard-token'
 export const ROKKA_DASHBOARD_ORG = 'rokka-dashboard-org'
@@ -10,9 +13,20 @@ export const apiTokenGetCallback = () => {
   return localStorage.getItem(ROKKA_DASHBOARD_TOKEN)
 }
 
+/**
+ * A client that authenticates with the plain Api-Key header (no JWT token
+ * callbacks). Needed for the MFA/TOTP enrollment from the login screen: an
+ * api key with requires_mfa but no TOTP set up yet can't get a token, it's
+ * only allowed to call the /user/mfa/totp endpoints directly.
+ */
+export function createApiKeyClient(apiKey) {
+  return rokka({ apiKey, apiHost, apiVersion: 1 })
+}
+
 export function authenticate(apiKey) {
   client = rokka({
     apiKey,
+    apiHost,
     apiVersion: 1,
     apiTokenOptions: {
       //no_ip_protection: true, // not sure about this
@@ -33,7 +47,7 @@ export function authenticate(apiKey) {
 }
 
 export function resetClient() {
-  client = rokka()
+  client = rokka({ apiHost })
 }
 
 const getClient = () => client

--- a/src/scss/components/_mfa.scss
+++ b/src/scss/components/_mfa.scss
@@ -1,0 +1,74 @@
+.rka-mfa-enrollment {
+  .rka-mfa-qr {
+    display: inline-block;
+    padding: $space-md;
+    background: $clr-white;
+    border: 1px solid $clr-gray-light;
+    border-radius: 4px;
+    margin: $space-md 0;
+  }
+
+  .rka-mfa-secret-label {
+    margin-bottom: $space-xs;
+    color: $clr-gray-darkest;
+    font-size: $font-sm;
+  }
+
+  .rka-mfa-secret {
+    display: flex;
+    align-items: center;
+    margin-bottom: $space-md;
+
+    code {
+      display: inline-block;
+      padding: $space-xs $space-sm;
+      background: $clr-gray-lightest;
+      border: 1px solid $clr-gray-light;
+      border-radius: 4px;
+      font-family: monospace;
+      letter-spacing: 1px;
+      margin-right: $space-sm;
+    }
+  }
+
+  .rka-mfa-actions {
+    display: flex;
+    align-items: center;
+    gap: $space-sm;
+  }
+}
+
+.rka-mfa-error {
+  color: $clr-cranberry;
+  font-size: $font-sm;
+  margin: $space-sm 0;
+}
+
+.rka-mfa-status {
+  display: inline-block;
+  padding: 2px $space-sm;
+  border-radius: 4px;
+  font-size: $font-xs;
+  font-weight: $font-bold;
+  text-transform: uppercase;
+
+  &.rka-mfa-status-active {
+    background: $clr-brand-lightest;
+    color: $clr-brand-dark;
+  }
+
+  &.rka-mfa-status-pending {
+    background: lighten($clr-orange-dark, 40%);
+    color: $clr-orange-dark;
+  }
+
+  &.rka-mfa-status-none {
+    background: $clr-gray-lighter;
+    color: $clr-gray-darkest;
+  }
+}
+
+.rka-button-small {
+  padding: $space-xs $space-sm;
+  font-size: $font-sm;
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -35,6 +35,7 @@
 @import 'components/costs';
 @import 'components/apikeys';
 @import 'components/login';
+@import 'components/mfa';
 @import 'components/modal';
 @import 'components/sidebar';
 @import 'components/spinner';

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -5,6 +5,7 @@ import rokka, {
   ROKKA_DASHBOARD_ORG,
   ROKKA_DASHBOARD_TOKEN,
 } from '../rokka'
+import { classifyMfaError } from '../utils/mfaErrors'
 
 if (localStorage.getItem(ROKKA_DASHBOARD_ORG) && apiTokenGetCallback()) {
   login(localStorage.getItem(ROKKA_DASHBOARD_ORG), '')
@@ -85,18 +86,25 @@ export function clearUploadedImages() {
  * @param {string}   organization
  * @param {string}   apiKey
  * @param {Function} successCb    Success callback
+ * @param {?string}  totp         TOTP (MFA) code, when the api key requires it
  *
  * @returns {Promise}
  */
-export function login(organization, apiKey, successCb) {
+export function login(organization, apiKey, successCb, totp) {
   authenticate(apiKey)
   const rka = rokka()
   //delete cookie, when token is not valid anymore
   if (rka.user.getTokenIsValidFor() < 0) {
     localStorage.removeItem(ROKKA_DASHBOARD_TOKEN)
   }
-  return rka.organizations
-    .get(organization)
+  // When logging in with an api key, mint the JWT token explicitly: MFA
+  // errors (mfa_required etc.) are only visible on the token endpoint
+  // itself, the implicit refresh inside other requests swallows them.
+  const mint = apiKey
+    ? rka.user.getNewToken(apiKey, totp ? { totp } : undefined)
+    : Promise.resolve()
+  return mint
+    .then(() => rka.organizations.get(organization))
     .then(() => {
       // remove alert in case there was auth failed before.
       removeAlert()
@@ -124,6 +132,12 @@ export function login(organization, apiKey, successCb) {
 
       // clear session
       localStorage.removeItem(ROKKA_DASHBOARD_TOKEN)
+
+      if (classifyMfaError(err)) {
+        // no global alert, the login screen renders the MFA/TOTP UI itself
+        updateState({ auth: null })
+        throw err
+      }
 
       if (err.statusCode === 403 || err.statusCode === 404 || err.statusCode === 401) {
         updateState({ auth: null })

--- a/src/utils/mfaErrors.js
+++ b/src/utils/mfaErrors.js
@@ -1,0 +1,22 @@
+export const MFA_REQUIRED = 'mfa_required'
+export const MFA_ENROLLMENT_REQUIRED = 'mfa_enrollment_required'
+export const TOTP_INVALID = 'totp_invalid'
+export const TOTP_RATE_LIMITED = 'totp_rate_limited'
+
+const MFA_ERRORS = [MFA_REQUIRED, MFA_ENROLLMENT_REQUIRED, TOTP_INVALID, TOTP_RATE_LIMITED]
+
+/**
+ * Classifies a rokka API error as one of the MFA/TOTP error codes, or null.
+ *
+ * MFA auth failures have a flat body shape ({error: 'mfa_required', ...}),
+ * unlike most other rokka errors, where body.error is an object with a
+ * message property. Both shapes are handled here.
+ *
+ * @param {*} err a caught rokka error (RokkaResponse)
+ *
+ * @returns {?string} one of the exported MFA error constants or null
+ */
+export function classifyMfaError(err) {
+  const error = err && err.body && err.body.error
+  return typeof error === 'string' && MFA_ERRORS.includes(error) ? error : null
+}

--- a/src/utils/mfaErrors.test.js
+++ b/src/utils/mfaErrors.test.js
@@ -1,0 +1,33 @@
+import {
+  classifyMfaError,
+  MFA_REQUIRED,
+  MFA_ENROLLMENT_REQUIRED,
+  TOTP_INVALID,
+  TOTP_RATE_LIMITED,
+} from './mfaErrors'
+
+describe('classifyMfaError', () => {
+  it('classifies flat MFA error bodies', () => {
+    expect(classifyMfaError({ body: { error: 'mfa_required' } })).toBe(MFA_REQUIRED)
+    expect(classifyMfaError({ body: { error: 'mfa_enrollment_required' } })).toBe(
+      MFA_ENROLLMENT_REQUIRED,
+    )
+    expect(classifyMfaError({ body: { error: 'totp_invalid' } })).toBe(TOTP_INVALID)
+    expect(classifyMfaError({ body: { error: 'totp_rate_limited' } })).toBe(TOTP_RATE_LIMITED)
+  })
+
+  it('returns null for other flat error strings', () => {
+    expect(classifyMfaError({ body: { error: 'something_else' } })).toBeNull()
+  })
+
+  it('returns null for the nested error object shape', () => {
+    expect(classifyMfaError({ body: { error: { message: 'Stack not found' } } })).toBeNull()
+  })
+
+  it('returns null for missing bodies and errors', () => {
+    expect(classifyMfaError(undefined)).toBeNull()
+    expect(classifyMfaError({})).toBeNull()
+    expect(classifyMfaError({ body: {} })).toBeNull()
+    expect(classifyMfaError({ statusCode: 401 })).toBeNull()
+  })
+})


### PR DESCRIPTION
## What

Client UI for the rokka-api TOTP/MFA feature. An Api Key can be flagged "requires MFA"; it can then only be exchanged for a JWT token together with a valid TOTP code from an authenticator app.

## Login flow

Progressive, so nothing changes for non-MFA users:
- Normal org + Api Key form as before.
- If the key requires MFA → a **code step** appears.
- If the key requires MFA but the user hasn't set up TOTP yet (e.g. a key rokka created for them) → a **QR-code enrollment wizard** appears; they scan it, enter a code, and are logged in with the same code.

`login()` now mints the JWT token explicitly before the org probe, so the MFA errors from the token endpoint (`mfa_required`, `mfa_enrollment_required`, `totp_invalid`, `totp_rate_limited`) are visible instead of being swallowed by the SDK's implicit token refresh. A mid-session `mfa_required` falls back to the login screen (unchanged clear-token-on-401 behavior).

## Api Keys page

- A **Two-factor authentication** section: set up TOTP (shows QR + secret), or disable it (asks for a code; disabling also clears the flag on all keys).
- A per-key **"Require MFA"** toggle (with a confirm dialog when flagging the key of the current session), and a **"Require MFA"** checkbox on key creation. Legacy (pre-2021) keys show `n/a` — they can't be flagged.

## Other

- New `MfaEnrollment` component, shared by the login flow and the apikeys page.
- `classifyMfaError()` helper for the flat MFA error body shape (`{error: 'mfa_required'}`), distinct from the usual nested `{error: {message}}`.
- `REACT_APP_API_HOST` env var to point the dashboard at a non-production rokka API for local development.
- New dependency `qrcode.react`.

## Tests

New: `mfaErrors`, `MfaEnrollment`, `Login`, `Apikeys`, `ApikeyRow`. Full suite green (139 tests, 32 suites), lint + prettier clean.

## ⚠️ Before merge

This depends on **`rokka` SDK 4.2.0** (rokka-io/rokka.js#91), which is not published yet. Once it's on npm:

1. `npm install` to regenerate `package-lock.json` (picks up `rokka@4.2.0` and the new `qrcode.react`). This commit intentionally leaves the lockfile untouched because a valid entry for the unpublished SDK version can't be generated yet.
2. Re-run `npm test` / `npm run build`.

## Manual verification checklist (against a local rokka-api)

Set `REACT_APP_API_HOST=http://api.rokka.test` in `.env.local`, then: enroll a pre-flagged key on first login; normal MFA login (wrong code → error, right code → in); reload keeps the session (renewable token, no re-prompt); apikeys page toggle / create-with-MFA / disable (unflags keys); rate limit → message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
