### PR TITLE
feat: add 'Your Memberships' tab listing all organizations you belong to

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -12,6 +12,7 @@ import '../scss/main.scss'
 import Apikeys from './Apikeys'
 import Signedup from './Signedup'
 import Memberships from './Memberships'
+import UserMemberships from './UserMemberships'
 
 class App extends PureComponent {
   constructor(props) {
@@ -39,6 +40,10 @@ class App extends PureComponent {
           <Route
             path="/memberships"
             render={(props) => <Memberships router={props} {...this.state} />}
+          />
+          <Route
+            path="/user-memberships"
+            render={(props) => <UserMemberships router={props} {...this.state} />}
           />
           <Route path="/signup" render={(props) => <Signup router={props} {...this.state} />} />
           <Route path="/signedup" render={(props) => <Signedup router={props} {...this.state} />} />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -41,7 +41,8 @@ class Sidebar extends PureComponent {
     const routePath = this.props.router.location.pathname
     const showStacks = routePath.indexOf('/stack') >= 0 || routePath.startsWith('/new-stack')
 
-    const showAccessControl = routePath === '/apikeys' || routePath === '/memberships'
+    const showAccessControl =
+      routePath === '/apikeys' || routePath === '/memberships' || routePath === '/user-memberships'
     const { currentOffset = 0, total = 0, filteredItems = [] } = this.props.stacks
     const tabindex = this.props.router.match.params.tabindex
     const $stacks = filteredItems
@@ -147,6 +148,14 @@ class Sidebar extends PureComponent {
               activeClassName="is-active"
             >
               Org Memberships
+            </NavLink>
+            <NavLink
+              to="/user-memberships"
+              exact
+              className="rka-sidebar-sublink"
+              activeClassName="is-active"
+            >
+              Your Memberships
             </NavLink>
           </div>
           <li>

--- a/src/components/UserMemberships.js
+++ b/src/components/UserMemberships.js
@@ -1,0 +1,127 @@
+import PropTypes from 'prop-types'
+import React, { PureComponent } from 'react'
+import { authRequired } from '../utils/auth'
+import BaseLayout from './layouts/BaseLayout'
+import rokka from '../rokka'
+import { login } from '../state'
+import { formatDate } from '../utils/string'
+
+const DEFAULT_STATE = {
+  loading: true,
+  error: false,
+  data: [],
+}
+
+class UserMemberships extends PureComponent {
+  constructor(props) {
+    super(props)
+    this.state = DEFAULT_STATE
+  }
+
+  componentDidMount() {
+    this.getMemberships()
+  }
+
+  getMemberships = () => {
+    rokka()
+      .request.request('user/memberships')
+      .then(({ body }) => {
+        this.setState({ loading: false, error: false, data: body.items || [] })
+      })
+      .catch(() => {
+        this.setState({ loading: false, error: true })
+      })
+  }
+
+  // Switching organization uses the current token (empty api key), so no
+  // re-authentication is needed: a rokka token is valid for the user across
+  // all organizations they are a member of.
+  switchOrganization = (organization) => {
+    if (organization === this.props.auth.organization) {
+      return
+    }
+    login(organization, '', () => this.props.router.history.push('/'))
+  }
+
+  getTable = (data) => {
+    return (
+      <table>
+        <tbody>
+          <tr className={'rka-h3 mb-md'}>
+            <th>Organization</th>
+            <th>Roles</th>
+            <th>Active</th>
+            <th>Last Access (updated every 24h)</th>
+            <th> </th>
+          </tr>
+          {data.map((membership) => {
+            const isCurrent = membership.organization === this.props.auth.organization
+            return (
+              <tr key={membership.organization_id || membership.organization}>
+                <td className={'mb-md'} style={{ height: '4em' }}>
+                  <strong>{membership.organization}</strong>
+                  {membership.display_name &&
+                  membership.display_name !== membership.organization ? (
+                    <div>{membership.display_name}</div>
+                  ) : null}
+                </td>
+                <td>{(membership.roles || []).join(', ')}</td>
+                <td>{membership.active ? 'yes' : 'no'}</td>
+                <td>{formatDate(membership.last_access, '')}</td>
+                <td>
+                  {isCurrent ? (
+                    <em>Current organization</em>
+                  ) : (
+                    <button
+                      className="rka-button rka-button-brand"
+                      onClick={() => this.switchOrganization(membership.organization)}
+                    >
+                      Switch to this organization
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    )
+  }
+
+  render() {
+    return (
+      <BaseLayout {...this.props}>
+        <div className="section rka-box no-min-height">
+          <h2 className={'rka-h2 mb-md'}>Your memberships</h2>
+          <div className={'mb-md'}>
+            All the organizations you are a member of. Click an organization to switch the dashboard
+            to it.
+          </div>
+        </div>
+        <div className="section rka-box no-min-height rka-table-apikeys">
+          {this.state.error ? (
+            <div>Could not load your memberships.</div>
+          ) : this.state.loading ? (
+            <div>Loading…</div>
+          ) : this.state.data.length === 0 ? (
+            <div>You are not a member of any organization.</div>
+          ) : (
+            this.getTable(this.state.data)
+          )}
+        </div>
+      </BaseLayout>
+    )
+  }
+}
+
+UserMemberships.propTypes = {
+  router: PropTypes.shape({
+    history: PropTypes.shape({
+      push: PropTypes.func.isRequired,
+    }).isRequired,
+  }).isRequired,
+  auth: PropTypes.object,
+}
+
+export { UserMemberships }
+export default authRequired(UserMemberships)

--- a/src/components/UserMemberships.test.js
+++ b/src/components/UserMemberships.test.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import { UserMemberships } from './UserMemberships'
+import rokka from '../rokka'
+import { login } from '../state'
+
+jest.mock('../rokka')
+jest.mock('../state')
+// render only the children, skip the full BaseLayout/Sidebar chrome
+jest.mock('./layouts/BaseLayout', () => ({ children }) => <div>{children}</div>)
+
+const flush = () => act(async () => {})
+
+const mockMemberships = (items) => ({
+  request: {
+    request: jest.fn().mockResolvedValue({ body: { total: items.length, items } }),
+  },
+})
+
+const props = {
+  router: { history: { push: jest.fn() } },
+  auth: { organization: 'currentorg', apiToken: 'token' },
+}
+
+const renderComponent = async () => {
+  let component
+  await act(async () => {
+    component = renderer.create(<UserMemberships {...props} />)
+  })
+  await flush()
+  return component
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('lists the organizations the user is a member of', async () => {
+  rokka.mockReturnValue(
+    mockMemberships([
+      { organization: 'currentorg', display_name: 'Current', roles: ['admin'], active: true },
+      { organization: 'otherorg', display_name: 'Other', roles: ['write'], active: true },
+    ]),
+  )
+  const component = await renderComponent()
+  const text = JSON.stringify(component.toJSON())
+  expect(text).toContain('otherorg')
+  expect(text).toContain('currentorg')
+})
+
+test('clicking another organization switches to it via login()', async () => {
+  rokka.mockReturnValue(
+    mockMemberships([
+      { organization: 'currentorg', display_name: 'Current', roles: ['admin'], active: true },
+      { organization: 'otherorg', display_name: 'Other', roles: ['write'], active: true },
+    ]),
+  )
+  const component = await renderComponent()
+  const switchButton = component.root
+    .findAllByType('button')
+    .find((b) => b.props.children === 'Switch to this organization')
+  expect(switchButton).toBeDefined()
+  act(() => switchButton.props.onClick())
+  expect(login).toHaveBeenCalledWith('otherorg', '', expect.any(Function))
+})

--- a/src/components/__snapshots__/NewStack.test.js.snap
+++ b/src/components/__snapshots__/NewStack.test.js.snap
@@ -161,6 +161,14 @@ exports[`NewStack does render with a previewImage 1`] = `
         >
           Org Memberships
         </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
+        </a>
       </div>
       <li>
         <a
@@ -659,6 +667,14 @@ exports[`NewStack does render with minimal props 1`] = `
         >
           Org Memberships
         </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
+        </a>
       </div>
       <li>
         <a
@@ -1090,6 +1106,14 @@ exports[`NewStack does render with stackOptions 1`] = `
           onClick={[Function]}
         >
           Org Memberships
+        </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
         </a>
       </div>
       <li>
@@ -1613,6 +1637,14 @@ exports[`NewStack does render with stacks 1`] = `
         >
           Org Memberships
         </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
+        </a>
       </div>
       <li>
         <a
@@ -2110,6 +2142,14 @@ exports[`newStack does render with clone stack props 1`] = `
           onClick={[Function]}
         >
           Org Memberships
+        </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
         </a>
       </div>
       <li>

--- a/src/components/__snapshots__/Sidebar.test.js.snap
+++ b/src/components/__snapshots__/Sidebar.test.js.snap
@@ -111,6 +111,14 @@ exports[`Sidebar does render 1`] = `
       >
         Org Memberships
       </a>
+      <a
+        aria-current={null}
+        className="rka-sidebar-sublink"
+        href="/user-memberships"
+        onClick={[Function]}
+      >
+        Your Memberships
+      </a>
     </div>
     <li>
       <a
@@ -247,6 +255,14 @@ exports[`Sidebar does render when active 1`] = `
         onClick={[Function]}
       >
         Org Memberships
+      </a>
+      <a
+        aria-current={null}
+        className="rka-sidebar-sublink"
+        href="/user-memberships"
+        onClick={[Function]}
+      >
+        Your Memberships
       </a>
     </div>
     <li>
@@ -424,6 +440,14 @@ exports[`Sidebar shows load more button 1`] = `
       >
         Org Memberships
       </a>
+      <a
+        aria-current={null}
+        className="rka-sidebar-sublink"
+        href="/user-memberships"
+        onClick={[Function]}
+      >
+        Your Memberships
+      </a>
     </div>
     <li>
       <a
@@ -592,6 +616,14 @@ exports[`Sidebar shows stacks 1`] = `
         onClick={[Function]}
       >
         Org Memberships
+      </a>
+      <a
+        aria-current={null}
+        className="rka-sidebar-sublink"
+        href="/user-memberships"
+        onClick={[Function]}
+      >
+        Your Memberships
       </a>
     </div>
     <li>

--- a/src/components/layouts/__snapshots__/BaseLayout.test.js.snap
+++ b/src/components/layouts/__snapshots__/BaseLayout.test.js.snap
@@ -161,6 +161,14 @@ exports[`BaseLayout does render 1`] = `
         >
           Org Memberships
         </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
+        </a>
       </div>
       <li>
         <a
@@ -361,6 +369,14 @@ exports[`BaseLayout does render active sidebar 1`] = `
         >
           Org Memberships
         </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
+        </a>
       </div>
       <li>
         <a
@@ -560,6 +576,14 @@ exports[`BaseLayout does render alert 1`] = `
           onClick={[Function]}
         >
           Org Memberships
+        </a>
+        <a
+          aria-current={null}
+          className="rka-sidebar-sublink"
+          href="/user-memberships"
+          onClick={[Function]}
+        >
+          Your Memberships
         </a>
       </div>
       <li>

--- a/src/state/__mocks__/index.js
+++ b/src/state/__mocks__/index.js
@@ -2,3 +2,5 @@ export function listStacks() {
   return {}
 }
 export function filterStacks() {}
+export const login = jest.fn()
+export const setAlert = jest.fn()


### PR DESCRIPTION
New tab under Access Control that calls the new GET /user/memberships endpoint and lists every organization the logged-in user is a member of (name, roles, active, last access). Clicking an organization switches the dashboard to it via the existing login() using the current token (no re-auth needed, since a rokka token is valid for the user across all their organizations).

Uses the SDK's generic request() helper (no SDK release needed). Adds login/ setAlert to the state test mock so components using them can be tested.